### PR TITLE
Stub GitHub Actions workflow for test-sqllogic

### DIFF
--- a/.github/workflows/test-sqllogic.yaml
+++ b/.github/workflows/test-sqllogic.yaml
@@ -1,0 +1,12 @@
+name: "Run sqllogictests"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-sqllogic:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          path: sqllogic-ztests


### PR DESCRIPTION
I want to develop a Workflow for running the ztests from GitHub Actions, but the Workflow needs to exist on `main` before I can test it on my branch. This adds a stub Workflow to kick things off.