### PR TITLE
Actions Workflow to notify on Slack when nightly runs fail

### DIFF
--- a/.github/workflows/notify-main-failure.yaml
+++ b/.github/workflows/notify-main-failure.yaml
@@ -1,0 +1,25 @@
+name: Notify main failure
+
+on:
+  workflow_run:
+    branches: 
+      - main
+    workflows:
+      - '**'
+    types:
+      - completed
+
+jobs:
+  slackNotify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'schedule' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Notify Brim HQ of failure of scheduled nightly runs
+        uses: tiloio/slack-webhook-action@v1.1.2
+        with:
+          slack_web_hook_url: ${{ secrets.SLACK_WEBHOOK_BRIMLABS_TEST }}
+          slack_json: |
+            {
+              "username": "github-actions",
+              "text": "Workflow \"${{ github.event.workflow_run.name }}\" failed on main.\n${{ github.event.workflow_run.html_url }}"
+            }  


### PR DESCRIPTION
This is based on a [similar workflow in the super repo](https://github.com/brimdata/super/blob/main/.github/workflows/notify-main-failure.yaml). One difference is that I've rigged this one up to only fire when the failure was in one of the nightly scheduled `cron`-style runs, since users might generate lots of failure noise if testing SuperDB branches-under-development using `workflow_dispatch` runs.