### PR TITLE
Delete unneeded tools to free up disk space

### DIFF
--- a/.github/workflows/test-sqllogic.yaml
+++ b/.github/workflows/test-sqllogic.yaml
@@ -57,6 +57,14 @@ jobs:
             pattern: TestSPQ/ztests/sqlite/random/select
     name: test-${{ matrix.test.name }}
     steps:
+      - name: Remove unneeded tools to free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/hostedtoolcache/node
+          sudo rm -rf /opt/hostedtoolcache/Python
+          sudo rm -rf /opt/hostedtoolcache/PyPy
+          sudo rm -rf /opt/hostedtoolcache/Ruby
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
       - uses: actions/checkout@v5
         with:
           repository: brimdata/super


### PR DESCRIPTION
In the past several days the nightly job has been failing during the `setup-go` phase with the following error:

```
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251205-081218-utc.log'
...
```

I did some hacking and confirmed that the contents of the directories removed in this branch are not needed for these tests. Once gone, the job has been able to proceed.

If I should need to free up even more space in the future, I could try removing the `/opt/hostedtoolcache/Go` directory as well and let `setup-go` download the bare minimum of what it needs. But I figured I'd start with something less aggressive and see how we fare.