### PR TITLE
Tweak the super patch to always have noheader TSV

### DIFF
--- a/super.patch
+++ b/super.patch
@@ -1,71 +1,17 @@
 diff --git a/sio/csvio/writer.go b/sio/csvio/writer.go
-index 0b2e73c43..49e135c70 100644
+index 79ffe3586..05aca139a 100644
 --- a/sio/csvio/writer.go
 +++ b/sio/csvio/writer.go
-@@ -17,16 +17,18 @@ import (
- var ErrNotDataFrame = errors.New("CSV output requires uniform records but multiple types encountered (consider 'fuse')")
- 
- type Writer struct {
--	writer    io.WriteCloser
--	encoder   *csv.Writer
--	flattener *expr.Flattener
--	types     map[int]struct{}
--	first     *super.TypeRecord
--	strings   []string
-+	writer      io.WriteCloser
-+	encoder     *csv.Writer
-+	flattener   *expr.Flattener
-+	types       map[int]struct{}
-+	first       *super.TypeRecord
-+	strings     []string
-+	writeHeader bool
- }
- 
- type WriterOpts struct {
--	Delim rune
-+	Delim       rune
-+	WriteHeader bool
- }
- 
- func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
-@@ -35,10 +37,11 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
- 		encoder.Comma = opts.Delim
- 	}
- 	return &Writer{
--		writer:    w,
--		encoder:   encoder,
--		flattener: expr.NewFlattener(super.NewContext()),
--		types:     make(map[int]struct{}),
-+		writer:      w,
-+		encoder:     encoder,
-+		flattener:   expr.NewFlattener(super.NewContext()),
-+		types:       make(map[int]struct{}),
-+		writeHeader: opts.WriteHeader,
+@@ -40,7 +40,7 @@ func NewWriter(w io.WriteCloser, opts WriterOpts) *Writer {
+ 		writer:    w,
+ 		encoder:   encoder,
+ 		flattener: expr.NewFlattener(super.NewContext()),
+-		header:    !opts.NoHeader,
++		header:    false,
+ 		types:     make(map[int]struct{}),
  	}
  }
- 
-@@ -62,12 +65,14 @@ func (w *Writer) Write(rec super.Value) error {
- 	}
- 	if w.first == nil {
- 		w.first = super.TypeRecordOf(rec.Type())
--		var hdr []string
--		for _, f := range rec.Fields() {
--			hdr = append(hdr, f.Name)
--		}
--		if err := w.encoder.Write(hdr); err != nil {
--			return err
-+		if w.writeHeader {
-+			var hdr []string
-+			for _, f := range rec.Fields() {
-+				hdr = append(hdr, f.Name)
-+			}
-+			if err := w.encoder.Write(hdr); err != nil {
-+				return err
-+			}
- 		}
- 	} else if _, ok := w.types[rec.Type().ID()]; !ok {
- 		if !fieldNamesEqual(w.first.Fields, rec.Fields()) {
-@@ -92,6 +97,9 @@ func (w *Writer) Write(rec super.Value) error {
+@@ -97,6 +97,9 @@ func (w *Writer) Write(rec super.Value) error {
  					s = strings.TrimSuffix(s, ".")
  				}
  			}


### PR DESCRIPTION
The enhancement in https://github.com/brimdata/super/pull/6449 gets us closer to being able to live without patching `super`, but to get all the way there still requires addressing what's described in https://github.com/brimdata/super/issues/5868. To keep the current approach going for now, this simplifies the patch to always have the "no header" option enabled regardless of CLI flag.