### PR TITLE
More easily run/count failures

### DIFF
--- a/.github/workflows/test-sqllogic.yaml
+++ b/.github/workflows/test-sqllogic.yaml
@@ -15,6 +15,15 @@ on:
         required: false
         default: false
         type: boolean
+      category:
+        description: 'Category of ztest files to run'
+        required: true
+        type: choice
+        options:
+        - yaml
+        - fail
+        - both
+        default: yaml
 
 jobs:
   setup:
@@ -65,6 +74,13 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/PyPy
           sudo rm -rf /opt/hostedtoolcache/Ruby
           sudo rm -rf /opt/hostedtoolcache/CodeQL
+      - name: Display workflow inputs
+        run: |
+          echo "Workflow Inputs:"
+          echo "  ref: ${{ github.event.inputs.ref || 'main (scheduled)' }}"
+          echo "  fail-fast: ${{ github.event.inputs.fail-fast || 'false (scheduled)' }}"
+          echo "  category: ${{ github.event.inputs.category || 'yaml (scheduled)' }}"
+          echo "  Event: ${{ github.event_name }}"
       - name: Checkout super
         run: |
           git clone https://github.com/brimdata/super.git super
@@ -83,24 +99,73 @@ jobs:
       - run: |
           patch -d super -p1 < sqllogic-ztests/super.patch
           make -C super build
-      - name: Run ${{ matrix.test.name }} tests
+      - name: Adjust which ztest files are run
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.category != 'yaml'
         run: |
           cd sqllogic-ztests
-          ZTEST_PATH="$(pwd)/../super/dist" go test . -timeout 6h -count=1 -run ${{ matrix.test.pattern }}
+          if [ "${{ github.event.inputs.category }}" = "fail" ]; then
+            find ztests -name "*.yaml" -delete
+          fi
+          if [ "${{ github.event.inputs.category }}" = "fail" ] || [ "${{ github.event.inputs.category }}" = "both" ]; then
+            rm -f ztests/sqlite/select5/ztests-1/*.fail || true
+            find ztests -name "*.fail" -print0 | xargs -0 -P 8 -n 100 bash -c 'for f; do mv "$f" "${f%.fail}.yaml"; done' _
+          fi
+      - name: Run ${{ matrix.test.name }} tests
+        id: run-tests
+        run: |
+          cd sqllogic-ztests
+          ZTEST_PATH="$(pwd)/../super/dist" go test . -timeout 6h -count=1 -run ${{ matrix.test.pattern }} 2>&1 | tee test-output.log || true
+          tests_ran=$(find $(echo "${{ matrix.test.pattern }}" | sed 's/^TestSPQ\///') -name \*.yaml | wc -l)
+          failure_count=$(grep "        --- FAIL" test-output.log | sed 's/.*FAIL: //' | sed 's/ (.*$//' | sort | uniq | wc -l)
+          echo "tests_ran=$tests_ran" | tee -a test-output.log
+          echo "success_count=$((tests_ran - failure_count))" | tee -a test-output.log
+          echo "failure_count=$failure_count" | tee -a test-output.log
+          if [ $failure_count -gt 0 ]; then
+            echo "HAS_FAILURES=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs-${{ matrix.test.name }}
+          path: sqllogic-ztests/test-output.log
+      - name: Fail job if tests failed
+        if: steps.run-tests.outputs.HAS_FAILURES == 'true'
+        run: exit 1
 
   summary:
     needs: test-sqllogic
     runs-on: ubuntu-22.04
     if: always()
     steps:
-      - name: Check test results
+      - name: Download all test logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-logs-*
+          path: logs
+      - name: Aggregate failure counts
         run: |
-          echo "Test Results Summary"
-          echo "===================="
-          results='${{ needs.test-sqllogic.result }}'
-          if [ "$results" != "success" ]; then
-            echo "❌ Some tests failed"
-            echo "Check individual job results above for details"
+          total_tests_ran=0
+          total_failures=0
+          total_successes=0
+          for log_dir in logs/test-logs-*; do
+            test_name=$(basename "$log_dir" | sed 's/test-logs-//')
+            log_file="$log_dir/test-output.log"
+            if [ -f "$log_file" ]; then
+              tests_ran=$(grep "^tests_ran=" "$log_file" | cut -f2 -d= || echo "0")
+              failure_count=$(grep "^failure_count=" "$log_file" | cut -f2 -d= || echo "0")
+              success_count=$(grep "^success_count=" "$log_file" | cut -f2 -d= || echo "0")
+              echo "$test_name: $tests_ran queries executed, $success_count successes, $failure_count failures"
+              total_tests_ran=$((total_tests_ran + tests_ran))
+              total_failures=$((total_failures + failure_count))
+              total_successes=$((total_successes + success_count))
+            else
+              echo "$test_name: log not found"
+            fi
+          done
+          echo "$total_tests_ran total tests executed, $total_successes total successes, $total_failures total failures"
+          if [ $total_failures -gt 0 ]; then
+            echo "❌ Tests had failures"
             exit 1
           else
             echo "✅ All test sets passed!"


### PR DESCRIPTION
When I first started this repo, I expected a workflow primarily focused on catching regressions, i.e., "lock in" a "golden" set of `.yaml` ztests known to contain successful queries, run them nightly to make sure they don't start breaking as SuperDB evolves, and add to the golden set over time as we fix SuperDB issues that make more queries succeed.

In practice, however, it's not worked out quite like that. Instead what's often happened is that I'll get to what I think is a golden set, but then fixing a SuperDB issue actually ends up breaking some queries from the golden set that had been passing for the wrong reasons. Also, regenerating an updated set of ztests from the original sqllogictests has been taking almost a week with inexpensive hardware, whereas running the existing ztests in GitHub Actions takes just a few hours. Therefore, finding easy to ways to run subsets of the ztests and check failure/success counts is a handy way to do things like verify issue fixes, check for unexpected changes, etc.

The changes in this PR help with this in a few ways:

1. While running the current golden set is still the default in nightly runs, a new `workflow_dispatch` option allows for running something other than the golden set. Specifically, one option allows running just the `.fail` ztests (i.e., ones that were known to fail in the last regen from the original sqllogictests, but maybe we want to check to see if some of them have started working thanks to recent SuperDB fixes) or running _both_ the `.yaml` (golden) and `.fail` ones (e.g., if we want to get an updated sense for the overall success rate inclusive of any unexpected fixes/regressions).

2. Success/failure counts now are tracked/reported both at the level of query group and overall.

3. The test logs for running each query group had to be turned into artifacts so they could be summarized at the end, and this turns out to be handy for manual downloading for inspection, since extracting them out of the overall run logs is more tedious.