### PR TITLE
Split random expr into two sets

### DIFF
--- a/.github/workflows/test-sqllogic.yaml
+++ b/.github/workflows/test-sqllogic.yaml
@@ -65,9 +65,14 @@ jobs:
             pattern: TestSPQ/ztests/sqlite/random/aggregates
             filter_dirs: true
             dir_range: "65-129"
-          - name: sqlite-random-expr
+          - name: sqlite-random-expr-part1
             pattern: TestSPQ/ztests/sqlite/random/expr
-            filter_dirs: false
+            filter_dirs: true
+            dir_range: "0-59"
+          - name: sqlite-random-expr-part2
+            pattern: TestSPQ/ztests/sqlite/random/expr
+            filter_dirs: true
+            dir_range: "60-119"
           - name: sqlite-random-groupby
             pattern: TestSPQ/ztests/sqlite/random/groupby
             filter_dirs: false


### PR DESCRIPTION
The full set of random "expr" tests have started taking around 6 hours to complete on a hosted GitHub Actions Runner, so this is sometimes causing the overall job to timeout before all tests have finished. Here we split them across two sets so each can half of the tests can run on a separate runner and have their results rolled up at the end, which is the approach that was used for other long-running test sets in #28.
